### PR TITLE
Add: `add_connection` query parameter to `connections` page

### DIFF
--- a/src/http/get-home-000view/connected-ticket.js
+++ b/src/http/get-home-000view/connected-ticket.js
@@ -1,0 +1,40 @@
+const data = require('@begin/data')
+const { Connection } = require('./connection')
+const { Ticket } = require('./ticket')
+
+class ConnectedTicket {
+  constructor(ticket) {
+    this._ticket = ticket
+  }
+
+  async connections() {
+    const connections = await Connection.connectionsForTicketKey(this._ticket.key)
+    const joinedToConnections = connections.map((connection) => this._joinToConnection(connection))
+    return Promise.all(joinedToConnections)
+  }
+
+  async addConnection(toTicket) {
+    const canConnect = await Connection.canConnect(this._ticket, toTicket)
+    if (!canConnect) {
+      await this._incrementBadConnection()
+      return
+    }
+    await Connection.addConnection(this._ticket, toTicket)
+  }
+
+  async _incrementBadConnection() {
+    await data.incr({ table: 'tickets', key: this._ticket.key, prop: 'bad_connects' })
+  }
+
+  async _joinToConnection(connection) {
+    const to_data = await Ticket.byKey(connection.to)
+    return {
+      ...connection,
+      to_data
+    }
+  }
+}
+
+module.exports = {
+  ConnectedTicket
+}

--- a/src/http/get-home-000view/connection.js
+++ b/src/http/get-home-000view/connection.js
@@ -1,0 +1,30 @@
+const data = require('@begin/data')
+let { getAll } = require('@architect/shared/utils/db-helper')
+
+class Connection {
+  static async allConnections() {
+    return await getAll('connections')
+  }
+
+  static async connectionsForTicketKey(ticketKey) {
+    const allConnections = await Connection.allConnections()
+    return allConnections.filter((connections) => connections.from === ticketKey)
+  }
+
+  static async addConnection(fromTicket, toTicket) {
+    const fromKey = fromTicket.key
+    const toKey = toTicket.key
+    await data.set({ table: 'connections', key: `${fromKey}-${toKey}`, from: fromKey, to: toKey })
+    await data.set({ table: 'connections', key: `${toKey}-${fromKey}`, from: toKey, to: fromKey })
+  }
+
+  static async canConnect(fromTicket, toTicket) {
+    const ticketsExist = fromTicket && toTicket
+    const underConnectionLimit = fromTicket.bad_connects < 10
+    return ticketsExist && underConnectionLimit
+  }
+}
+
+module.exports = {
+  Connection
+}

--- a/src/http/get-home-000view/index.js
+++ b/src/http/get-home-000view/index.js
@@ -25,7 +25,7 @@ async function fetchConnections(cursor) {
 }
 
 async function getActivitiesWithCounts() {
-  let rsvpData = await data.get({table: 'rsvps', limit: 500 })
+  let rsvpData = await data.get({ table: 'rsvps', limit: 500 })
   return activities.map(a => {
     return {
       ...a,
@@ -49,18 +49,18 @@ async function unauthenticated(req) {
   }
   else if (view === 'verify') {
     let { ticketRef, token } = req.queryStringParameters
-    let login = await data.get( { table: 'logins', key: ticketRef })
+    let login = await data.get({ table: 'logins', key: ticketRef })
     if (login && login.token === token && login.expires > Date.now()) {
       let session = { ticketRef }
       let location = '/home/dashboard'
       return { session, location }
     }
     else {
-      return { location: `/home/login?message=${ encodeURIComponent("Log-in verification failed, try again?") }`}
+      return { location: `/home/login?message=${encodeURIComponent("Log-in verification failed, try again?")}` }
     }
   }
   else if (!ticketRef) {
-    return { location: `/home/login?message=${ encodeURIComponent("Please log-in") }`}
+    return { location: `/home/login?message=${encodeURIComponent("Please log-in")}` }
   }
 }
 
@@ -69,10 +69,10 @@ async function authenticated(req) {
   let { message } = req.queryStringParameters
   const { view } = req.params
   let { ticketRef } = req.session
-  let ticket = await data.get( { table: 'tickets', key: ticketRef })
+  let ticket = await data.get({ table: 'tickets', key: ticketRef })
   if (view === 'dashboard') {
     // load the RSVP (if one exists)
-    let rsvp = await data.get({table: 'rsvps', key: ticketRef })
+    let rsvp = await data.get({ table: 'rsvps', key: ticketRef })
     let activitiesWithCounts = await getActivitiesWithCounts()
     //console.log(activitiesWithCounts)
     return HomeView({ ticket, rsvp, activities: activitiesWithCounts, message })
@@ -94,7 +94,7 @@ async function authenticated(req) {
       for (let i in connections) {
         let conn = connections[i]
         let to_data = await fetchToData(conn.to)
-        connections[i] = { ...conn, to_data}
+        connections[i] = { ...conn, to_data }
       }
       //console.log(connections)
     }
@@ -110,7 +110,7 @@ async function authenticated(req) {
       return ConnectView({ ticket, connections })
     }
   }
-  else if (view === 'wait'){
+  else if (view === 'wait') {
     return WaitView()
   }
   else if (view === 'oauth') {

--- a/src/http/get-home-000view/ticket.js
+++ b/src/http/get-home-000view/ticket.js
@@ -1,0 +1,20 @@
+const data = require('@begin/data')
+
+class Ticket {
+  static async byKey(key) {
+    return await data.get({ table: 'tickets', key })
+  }
+
+  static async allTickets() {
+    return data.get({ table: 'tickets', limit: 1000 })
+  }
+
+  static async fromConnectionHash(connectionHash) {
+    const tickets = await Ticket.allTickets()
+    return tickets.find((ticket) => ticket.conn_hash === connectionHash)
+  }
+}
+
+module.exports = {
+  Ticket
+}

--- a/src/views/home/connect.js
+++ b/src/views/home/connect.js
@@ -5,6 +5,7 @@ module.exports = async function({ ticket, connections }) {
         <div id=page>
             <div class=page-title><div><h1>Connect 🤝</h1></div></div>
             <div class=page-body class=narrow>
+            <div class="cta"><a id="copy-sharing-url-button" href="/home/connect?add_connection=${ c.conn_hash }">Copy Sharing URL 🔗➡️📋</a></div>
             <h2>Make a Connection</h2>
             <iframe id="retool-app" height="525" scrolling="no" allow="camera" style="border:none" src="https://retoolin.tryretool.com/embedded/public/3997468d-a0cf-4d2f-b18e-055db698b133?auth_hash=${ encodeURIComponent(ticket.auth_hash) }"></iframe>
             <h2>Your Connections</h2>
@@ -26,6 +27,12 @@ module.exports = async function({ ticket, connections }) {
                 window.addEventListener('message', (event) => {
                     if (event.data === 'reload') window.location.reload();
                 });
+
+                const copySharingUrlButton = document.getElementById("copy-sharing-url-button");
+                copySharingUrlButton.addEventListener('click', (e) => {
+                    e.preventDefault();
+                    navigator.clipboard.writeText("https://2022.cascadiajs.com/home/connect?add_connection=${ c.conn_hash }")
+                })
             </script>
         </div>
     `


### PR DESCRIPTION
This allows ticket holders to connect to one another by sharing a URL with one another.

When an authenticated ticket holder clicks another user's sharing URL it will try to add the targeted ticket holder by their connection hash (6 character sharable hash/ID).

ie: `https://2022.cascadiajs.com/home/connect?add_connection=012345`

## Notes
- I could not get this to run locally due to missing/undocumented environment variables
- This code is untested 💀 
- There should be some messaging upon success or failure (too many failures to add a connection)
  - If a user hits their bad connection limit it's like a soft ban I guess (they can no longer try to add people)?
    - Should this continue to be enforced? What was the original intention?
    - If someone wanted to be malicious they can get users soft banned by sharing a bad URL. Previously this was mitigated more easily by QR codes that were generated and scanned within the environment. A user could have a bad QR code, but would have had to gone out of their way or shared outside of the app (which is currently happening in the Discord `connect` channel). End users could also scan random QR codes which could flag them.
- Some of these classes like the: `Ticket`, `Connection`, and `ConnectedTicket` could be shared across code. The first that comes to mind would be the `post-api-connect/index.js`
- Maybe we should prevent ticket holders from adding themselves? This is already currently possible if you scan your own QR code.

## Warning/PS

I have no clue if this will work. Efforts around data handling were via implicit inference of the code. I was also unable to run the local dev server to try this due to missing environment variables, so this is really flying blind, but hopefully gets a nice feature close to a working implementation 😬 I honestly don't expect this to work first try and flying blind.