### PR TITLE
Fix clipboard not copying properly

### DIFF
--- a/src/views/home/connect.js
+++ b/src/views/home/connect.js
@@ -34,9 +34,9 @@ module.exports = async function({ ticket, connections, message }) {
                 });
 
                 const copySharingUrlButton = document.getElementById("copy-sharing-url-button");
-                copySharingUrlButton.addEventListener('click', (e) => {
+                copySharingUrlButton.addEventListener('click', async (e) => {
                     e.preventDefault();
-                    navigator.clipboard.writeText("https://2022.cascadiajs.com/home/connect?add_connection=${ conn_hash }")
+                    await navigator.clipboard.writeText("https://2022.cascadiajs.com/home/connect?add_connection=${ conn_hash }")
                     alert("URL copied to your clipboard")
                 })
             </script>


### PR DESCRIPTION
This hopefully fixes the issue where the URL doesn't copy to the clipboard due to the following error:

```
DOMException: Document is not focused.
```

Related Stack Overflow: https://stackoverflow.com/a/71803694/349659
TLDR; the alert box is stealing the document focus, so the action should be awaited to avoid this.

Note: this is a blind edit made in the Github UI 🤞